### PR TITLE
Modexp ab2

### DIFF
--- a/src/circuits/mod.rs
+++ b/src/circuits/mod.rs
@@ -243,6 +243,33 @@ impl CommonGateConfig {
         /* todo
          * constraint all the limbs to be either 1 or 0
          */
+
+        // apply eqn: (val * val) - val = 0,
+        // by: (ws[1] * ws[2] * cs[7]) + (ws[0] * cs[0]) = 0,
+        for i in 0..(limbs.len()) {
+            let lm = limbs[i].clone();
+            let _l = self.assign_line(
+                region,
+                range_check_chip,
+                offset,
+                [
+                    Some(lm.clone()),
+                    Some(lm.clone()),
+                    Some(lm),
+                    None,              
+                    None,
+                    None,
+                ],
+                [
+                    Some(-F::one()), None, None, None, None, None,
+                    None,
+                    Some(F::one()),
+                    None,
+                ],
+                0  //what is limbbound
+            )?;
+        }
+
         Ok(())
     }
 

--- a/src/circuits/modexp.rs
+++ b/src/circuits/modexp.rs
@@ -263,20 +263,24 @@ impl<F: FieldExt> ModExpChip<F> {
         Ok(l[3].clone())
     }
 
+    ///
+    /// # Apply constraint:
+    /// (r     * 1    ) + (x0    * y0    * 1    ) + (v     * 1    ) = 0 \
+    /// (ws[0] * cs[0]) + (ws[1] * ws[2] * cs[7]) + (ws[4] * cs[4]) = 0
+    /// 
     pub fn mod_power216_mul (
-       &self,
-       region: &mut Region<F>,
-       range_check_chip: &mut RangeCheckChip<F>,
-       offset: &mut usize,
-       lhs: &Number<F>,
-       rhs: &Number<F>,
-    ) -> Result<Limb<F>, Error> {
+        &self,
+        region: &mut Region<F>,
+        range_check_chip: &mut RangeCheckChip<F>,
+        offset: &mut usize,
+        lhs: &Number<F>,
+        rhs: &Number<F>,
+     ) -> Result<Limb<F>, Error> {
         let x0 = lhs.limbs[0].value;
         let x1 = lhs.limbs[1].value;
         let y0 = rhs.limbs[0].value;
         let y1 = rhs.limbs[1].value;
-
-        let mut v =  x0 * y1 + x1 * y0; // 219 bits
+        let mut v =  x0 * y1 + x1 * y0; //0-2^216
         let l = self.config.assign_line(
             region,
             range_check_chip,
@@ -292,11 +296,11 @@ impl<F: FieldExt> ModExpChip<F> {
             [None, None, None, None, Some(-F::one()), None, Some(F::one()), Some(F::one()), None],
             0
         )?;
-        let vcell = l[4].clone(); // 219 bits
+        let vcell = l[4].clone();
 
         //  compute v mod 2^108
-        let bn_q = field_to_bn(&v).div(BigUint::from(1u128<<108)); // bn_q is 109 bits
-        let bn_r = field_to_bn(&v) - bn_q.clone() * BigUint::from(1u128 << 108); // 108 bits
+        let bn_q = field_to_bn(&v).div(BigUint::from(1u128<<108));
+        let bn_r = field_to_bn(&v) - bn_q.clone() * BigUint::from(1u128 << 108);
         let q = Limb::new(None, bn_to_field(&bn_q));
         let r = Limb::new(None, bn_to_field(&bn_r));
 
@@ -308,27 +312,26 @@ impl<F: FieldExt> ModExpChip<F> {
             [Some(F::from_u128(1u128<<108)), Some(-F::one()), None, Some(F::one()), None, None, None, None, None],
             10,
         )?;
-
-        let rcell = l[2].clone(); // 108 bits unchecked
-
-        v = rcell.value * F::from_u128(1u128<<108) + x0 + y0;
+        let rcell = l[2].clone();
+        v = rcell.value * F::from_u128(1u128<<108) + x0 * y0;
 
         let l = self.config.assign_line(
             region,
             range_check_chip,
             offset,
             [
-                Some(lhs.limbs[0].clone()),
                 Some(rcell),
-                None,
+                Some(lhs.limbs[0].clone()),
                 Some(rhs.limbs[0].clone()),
+                None,
                 Some(Limb::new(None, v)),
                 None
             ],
-            [Some(F::one()), Some(F::from_u128(1u128<<108)), None, Some(F::one()), Some(-F::one()), None, None, None, None],
+            [Some(F::from_u128(1u128<<108)), None, None, None, Some(-F::one()), 
+                    None, None, Some(F::one()), None
+            ],
             0 // TODO: need to check rcell range
         )?;
-
         Ok(l[3].clone())
     }
 
@@ -361,6 +364,10 @@ impl<F: FieldExt> ModExpChip<F> {
         Ok(())
     }
 
+    ///
+    /// # Apply constraint:
+    /// (q * -c) + (sum(limb_i * sign_i)) + (c * BUFMULT)  = 0 
+    /// 
     pub fn mod_power216_zero(
        &self,
        region: &mut Region<F>,
@@ -369,7 +376,27 @@ impl<F: FieldExt> ModExpChip<F> {
        limbs: Vec<Limb<F>>,
        signs: Vec<F>,
     ) -> Result<(), Error> {
-        //todo!()
+        const BUFMULT: u128 = 2u128;    // as long as its > 2-bits wide.
+        let f_c = F::from_u128(1u128<<108) * F::from_u128(1u128<<108);
+        let f_cm = f_c * F::from_u128(BUFMULT);
+        let v = (f_c * F::from_u128(BUFMULT)) 
+                + limbs[0].value*signs[0] + limbs[1].value *signs[1] + limbs[2].value*signs[2];
+        let q = field_to_bn(&v).div(field_to_bn(&f_c));
+        self.config.assign_line(
+            region,
+            range_check_chip,
+            offset,
+            [
+                Some(Limb::new(None, bn_to_field(&q))),
+                Some(limbs[0].clone()),
+                Some(limbs[1].clone()),
+                Some(limbs[2].clone()),
+                None,
+                None ],
+            [Some(-f_c), Some(signs[0]), Some(signs[1]), Some(signs[2]), 
+                    None, None, None, None, Some(f_cm) ],
+            1 // check rcell range
+        )?;
         Ok(())
     }
 
@@ -861,46 +888,10 @@ mod tests_2 {
 
     }
 
-    //------------------------------------------------------------
-    use std::fmt;
-    use halo2_proofs::{
-        dev::{
-            VerifyFailure, 
-            FailureLocation,
-        },
-        plonk::Any,
-    };
-    
-    pub enum CircuitError {
-        /// Thrown when `MockProver::run` fails to prove the circuit.
-        ProverError(Error),
-        /// Thrown when verification fails.
-        VerifierError(Vec<VerifyFailure>),
-        /// Thrown when no operation has been specified.
-        NoOperation,
-    }
-    
-    impl fmt::Debug for CircuitError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match self {
-                CircuitError::ProverError(prover_error) => {
-                    write!(f, "prover error in circuit: {}", prover_error)
-                }
-                CircuitError::VerifierError(verifier_error) => {
-                    write!(f, "verifier error in circuit: {:#?}", verifier_error)
-                }
-                CircuitError::NoOperation => {
-                    write!(f, "no operation is set (this should never happen.")
-                }
-            }
-        }
-    }
-    //------------------------------------------------------------
-
-    #[derive(Clone, Debug, Default)]
-    struct TestDecomposeLimbCircuit {
-        l: BigUint,
-    }
+    // #[derive(Clone, Debug, Default)]
+    // struct TestDecomposeLimbCircuit {
+    //     l: BigUint,
+    // }
 
     #[derive(Clone, Debug)]
     struct TestConfig {
@@ -913,6 +904,7 @@ mod tests_2 {
     #[derive(Clone, Debug, Default)]
     struct TestModpower108m1Circuit {
         a: BigUint,
+        bn_test_res: BigUint,
     }
 
     impl Circuit<Fr> for TestModpower108m1Circuit {
@@ -945,18 +937,20 @@ mod tests_2 {
                 |mut region| {
                     range_chip.initialize(&mut region)?;
                     let mut offset = 0;
-                    let bn_rem = self.a.clone()  % (BigUint::from(1u128 << 108) - BigUint::from(1u128));
+                    //let bn_rem = self.a.clone()  % (BigUint::from(1u128 << 108) - BigUint::from(1u128));
+                    let bn_res = &self.bn_test_res;
                     let a = helperchip.assign_base(&mut region, &mut offset, &self.a)?;
-                    let result = helperchip.assign_results(&mut region, &mut offset, &bn_rem)?;
+                    let result = helperchip.assign_results(&mut region, &mut offset, &bn_res)?;
                     let rem = modexpchip.mod_power108m1(&mut region, &mut range_chip, &mut offset, &a )?;
-                    println!("bn_res = 0x{}", bn_rem.to_str_radix(16));
+                    
+                    println!("\nbn_res \t\t= 0x{}", bn_res.to_str_radix(16));
                     println!("\nrem is (hex):");
                     for i in 0..4 {
-                        println!("rem[{i}] = {:?}", &rem[i].value);
+                        println!("rem[{i}] \t\t= {:?}", &rem[i].value);
                     }
                     for i in 0..4 {
-                        println!("result is {:?}", &result.limbs[i].value);
-                        println!("resultcell is {:?}", &result.limbs[i].cell);
+                        println!("result[{}] \t= {:?}", i, &result.limbs[i].value);
+                        println!("resultcell[{}] \t= {:?}",i, &result.limbs[i].cell);
                         // region.constrain_equal(
                         //     rem.limbs[i].clone().cell.unwrap().cell(),
                         //     result.limbs[i].clone().cell.unwrap().cell()
@@ -1077,6 +1071,7 @@ mod tests_2 {
         l: BigUint,
         r: BigUint,
         modulus: BigUint,
+        bn_test_res: BigUint,
     }
 
     impl Circuit<Fr> for TestModMultCircuit {
@@ -1109,17 +1104,20 @@ mod tests_2 {
                 |mut region| {
                     range_chip.initialize(&mut region)?;
                     let mut offset = 0;
-                    let bn_rem = self.l.clone() * self.r.clone() % self.modulus.clone();
-                    let result = helperchip.assign_results(&mut region, &mut offset, &bn_rem)?;
+                    let result = helperchip.assign_results(&mut region, &mut offset, &self.bn_test_res)?;
                     let modulus  = helperchip.assign_modulus(&mut region, &mut offset, &self.modulus)?;
                     let lhs  = helperchip.assign_base(&mut region, &mut offset, &self.l)?;
                     let rhs  = helperchip.assign_base(&mut region, &mut offset, &self.r)?;
-                    let res = modexpchip.mod_mult(&mut region, &mut range_chip,&mut offset, &lhs, &rhs, &modulus)?;     
-                    println!("\nbn_rem    = {:?}", bn_rem);
+                    let rem = modexpchip.mod_mult(&mut region, &mut range_chip,&mut offset, &lhs, &rhs, &modulus)?;     
                     for i in 0..4 {
-                        println!("res = {:?}", &res.limbs[i].value);
+                        println!("rem is {:?}, result is {:?}", &rem.limbs[i].value, &result.limbs[i].value);
+                        println!("remcell is {:?}, resultcell is {:?}", &rem.limbs[i].cell, &result.limbs[i].cell);
+                        region.constrain_equal(
+                            rem.limbs[i].clone().cell.unwrap().cell(),
+                            result.limbs[i].clone().cell.unwrap().cell()
+                        )?;
                     }
-                    Ok(res)
+                    Ok(rem)
                 }
             )?;
             Ok(())
@@ -1131,6 +1129,7 @@ mod tests_2 {
         base: BigUint,
         exp: BigUint,
         modulus: BigUint,
+        bn_test_res: BigUint,
     }
 
     impl Circuit<Fr> for TestModExpCircuit {
@@ -1166,13 +1165,12 @@ mod tests_2 {
                     let base = helperchip.assign_base(&mut region, &mut offset, &self.base)?;
                     let exp = helperchip.assign_exp(&mut region, &mut offset, &self.exp)?;
                     let modulus = helperchip.assign_modulus(&mut region, &mut offset, &self.modulus)?;
-                    let bn_rem = self.base.clone().modpow(&self.exp, &self.modulus);
-                    let result = helperchip.assign_results(&mut region, &mut offset, &bn_rem)?;
+                    let result = helperchip.assign_results(&mut region, &mut offset, &self.bn_test_res)?;
                     let rem = modexpchip.mod_exp(&mut region, &mut range_chip, &mut offset, &base, &exp, &modulus)?;
                     for i in 0..4 {
-                        println!("rem is {:?}, \t result is {:?}", &rem.limbs[i].value, &result.limbs[i].value);
-                        println!("remcell is \t{:?}", &rem.limbs[i].cell);
-                        println!("resultcell is \t {:?}", &result.limbs[i].cell);
+                        // println!("rem is {:?}, \t result is {:?}", &rem.limbs[i].value, &result.limbs[i].value);
+                        // println!("remcell is \t{:?}", &rem.limbs[i].cell);
+                        // println!("resultcell is \t {:?}", &result.limbs[i].cell);
                         region.constrain_equal(
                             rem.limbs[i].clone().cell.unwrap().cell(),
                             result.limbs[i].clone().cell.unwrap().cell()
@@ -1186,32 +1184,40 @@ mod tests_2 {
     }
 
     fn run_mod_power108m1_circuit() -> Result<(), CircuitError> {
-        // test mod_power108m1 for over x bits
-        let mut rng = thread_rng();
-        let bit_len = (LIMB_WIDTH + LIMB_WIDTH + 108) as u64;
-        let mut b = BigUint::default();
-        while b.bits() != bit_len {
-            b = rng.sample(RandomBits::new(bit_len));
+        // Create an a set of test vectors varying in bit lengths.
+        // Test will pass if:
+        //  (1) result returned from circuit constrain_equal() to the 
+        //      assigned result from bn calculation. 
+        //  (2) prover.verify() for each run verifies without error.
+        let mut bn_test_vectors: Vec<BigUint> = Vec::with_capacity(8);
+        let bit_len: [usize; 8] = [
+                0,
+                1,
+                LIMB_WIDTH + LIMB_WIDTH + LIMB_WIDTH + 1,
+                LIMB_WIDTH,
+                LIMB_WIDTH + 1,
+                LIMB_WIDTH + 108,
+                LIMB_WIDTH + LIMB_WIDTH + 1,
+                LIMB_WIDTH + LIMB_WIDTH + 108,
+            ];
+        for i in 0..8 {
+            bn_test_vectors.push(get_random_x_bit_bn(bit_len[i]));
         }
-        let a = b;
-        println!("bit_len = {}", bit_len);
-        println!("a = 0x{}", a.to_str_radix(16));
-
-        let a = BigUint::parse_bytes(b"FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", 16).unwrap() 
-            * BigUint::parse_bytes(b"2", 16).unwrap() + BigUint::parse_bytes(b"1", 16).unwrap();  
-        // test expected overflow of 1 bit 0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffff
-
-        let test_circuit = TestModpower108m1Circuit{a} ;
-        let prover = match MockProver::run(16, &test_circuit, vec![]) {
-            Ok(prover_run) => prover_run,
-            Err(prover_error) => return Err(CircuitError::ProverError(prover_error)),
-        };
-        //assert_eq!(prover.verify(), Ok(()));
-        match prover.verify() {
-            Ok(_) => (),
-            Err(verifier_error) => return Err(CircuitError::VerifierError(verifier_error)),
-        };
-
+        for testcase in bn_test_vectors {
+            let (a_l2, a_l1, a_l0) = get_limbs_from_bn(&testcase);
+            let bn_l210sum = &a_l2 + &a_l1 + &a_l0;
+            let bn_test_res = bn_l210sum;
+            let a = testcase.clone();
+            let test_circuit = TestModpower108m1Circuit{a, bn_test_res} ;
+            let prover = match MockProver::run(16, &test_circuit, vec![]) {
+                Ok(prover_run) => prover_run,
+                Err(prover_error) => return Err(CircuitError::ProverError(prover_error)),
+            };
+            match prover.verify() {
+                Ok(_) => (),
+                Err(verifier_error) => return Err(CircuitError::VerifierError(verifier_error)),
+            };
+        }
         Ok(())
     }
 
@@ -1236,9 +1242,9 @@ mod tests_2 {
 
     fn run_mod_power216_mul_circuit() -> Result<(), CircuitError> {
 
-        let l = BigUint::from(2454u128);
-        let r = BigUint::from(1u128);
-        let modulus = BigUint::from(1u128<<108) * BigUint::from(1u128<<108);
+        let l = get_random_x_bit_bn( LIMB_WIDTH + LIMB_WIDTH + 42);
+        let r = get_random_x_bit_bn(LIMB_WIDTH - 47);
+        let modulus = get_random_x_bit_bn(16);
         let test_circuit = TestModPower216MulCircuit{l, r, modulus} ;
         let prover = match MockProver::run(16, &test_circuit, vec![]) {
             Ok(prover_run) => prover_run,
@@ -1265,77 +1271,227 @@ mod tests_2 {
         Ok(())
     }
 
-    fn run_mod_mult_circuit() -> Result<(), CircuitError> {
+    fn run_mod_mult_circuit() -> Result<(), CircuitError> {   
+        const NUM_TESTS: usize = 6;
+        let mut bn_lhs_test_vectors: Vec<BigUint> = Vec::with_capacity(NUM_TESTS);
+        let mut bn_rhs_test_vectors: Vec<BigUint> = Vec::with_capacity(NUM_TESTS);
+        let mut bn_modulus_test_vectors: Vec<BigUint> = Vec::with_capacity(NUM_TESTS);
+        let bit_len_l: [usize; NUM_TESTS] = [1,4,8,
+            LIMB_WIDTH - 1,
+            LIMB_WIDTH + 1,
+            LIMB_WIDTH + LIMB_WIDTH + 1,]; 
+        let bit_len_r: [usize; NUM_TESTS] = [1,4,8,
+            LIMB_WIDTH - 1,
+            LIMB_WIDTH + 36,
+            LIMB_WIDTH + LIMB_WIDTH + 10,]; // + 12 will error
+        let bit_len_m: [usize; NUM_TESTS] = [1,4,8,12,16,20,]; 
 
-        let l = BigUint::from(2454u128);
-        let r = BigUint::from(1u128);
-        let modulus = BigUint::from(18u128);
-        let test_circuit = TestModMultCircuit{l, r, modulus} ;
-        let prover = match MockProver::run(16, &test_circuit, vec![]) {
-            Ok(prover_run) => prover_run,
-            Err(prover_error) => return Err(CircuitError::ProverError(prover_error)),
-        };
-        match prover.verify() {
-            Ok(_) => (),
-            Err(verifier_error) => return Err(CircuitError::VerifierError(verifier_error)),
-        };
+        for i in 0..NUM_TESTS {
+            bn_lhs_test_vectors.push(get_random_x_bit_bn(bit_len_l[i]));
+            bn_rhs_test_vectors.push(get_random_x_bit_bn(bit_len_r[i]));
+            bn_modulus_test_vectors.push(get_random_x_bit_bn(bit_len_m[i]));
+        }
+        for i in 0..NUM_TESTS  {
+            let lhs_testcase = bn_lhs_test_vectors[i].clone();
+            let rhs_testcase = bn_rhs_test_vectors[i].clone();
+            let modulus_testcase = bn_modulus_test_vectors[i].clone();
+
+            let bn_test_res = (lhs_testcase.clone() * rhs_testcase.clone() ) % modulus_testcase.clone() ;
+            println!("testcase: (0x{})*(0x{}) mod 0x{} = 0x{}", lhs_testcase.clone().to_str_radix(16),
+                                        rhs_testcase.clone().to_str_radix(16),
+                                        modulus_testcase.clone().to_str_radix(16),
+                                        bn_test_res.to_str_radix(16));
+
+            let l = lhs_testcase.clone();
+            let r = rhs_testcase.clone();
+            let modulus = modulus_testcase.clone();
+            let test_circuit = TestModMultCircuit{l, r, modulus, bn_test_res} ;
+            let prover = match MockProver::run(16, &test_circuit, vec![]) {
+                Ok(prover) => prover,
+                Err(e) => panic!("{:#?}", e)
+            };
+            match prover.verify() {
+                Ok(_) => (),
+                Err(verifier_error) => return Err(CircuitError::VerifierError(verifier_error)),
+            };
+        }
         Ok(())
     }
 
     fn run_modexp_circuit() -> Result<(), CircuitError> {
+        // Create an a set of test vectors varying in bit lengths for base, exp & modulus.
+        // Test will pass if:
+        //  (1) result returned from circuit constrain_equal() to the 
+        //      assigned result from bn calculation. 
+        //  (2) prover.verify() for each run verifies without error.
 
-        let base = BigUint::from(5u128); 
-        let exp = BigUint::from(22u128);
-        let modulus = BigUint::from(37u128);
-        let test_circuit = TestModExpCircuit {base, exp, modulus} ;
-
-        let prover = match MockProver::run(16, &test_circuit, vec![]) {
-            Ok(prover_run) => prover_run,
-            Err(prover_error) => return Err(CircuitError::ProverError(prover_error)),
-        };
-    
-        match prover.verify() {
-            Ok(_) => (),
-            Err(verifier_error) => return Err(CircuitError::VerifierError(verifier_error)),
-        };
-
+        const NUM_TESTS: usize = 5;
+        let mut bn_base_test_vectors: Vec<BigUint> = Vec::with_capacity(NUM_TESTS);
+        let mut bn_modulus_test_vectors: Vec<BigUint> = Vec::with_capacity(NUM_TESTS);
+        let mut bn_exp_test_vectors: Vec<BigUint> = Vec::with_capacity(NUM_TESTS);
+        let bit_len_b: [usize; NUM_TESTS] = [1,4,8,10,16,]; 
+        let bit_len_m: [usize; NUM_TESTS] = [1,4,8,16,20,]; 
+        let bit_len_e: [usize; NUM_TESTS] = [ //change for larger exp bit length.
+                1,
+                LIMB_WIDTH - 1,
+                LIMB_WIDTH + 1,
+                LIMB_WIDTH + LIMB_WIDTH - 1,
+                LIMB_WIDTH + LIMB_WIDTH + LIMB_WIDTH - 90, // max before overflow (need to check range)
+            ];  
+        for i in 0..NUM_TESTS {
+            bn_base_test_vectors.push(get_random_x_bit_bn(bit_len_b[i]));
+            bn_modulus_test_vectors.push(get_random_x_bit_bn(bit_len_m[i]));
+            bn_exp_test_vectors.push(get_random_x_bit_bn(bit_len_e[i]));
+        }
+        for i in 0..NUM_TESTS  {
+            let base_testcase = bn_base_test_vectors[i].clone();
+            let modulus_testcase = bn_modulus_test_vectors[i].clone();
+            let exp_testcase = bn_exp_test_vectors[i].clone();
+            //let bn_test_res = big_pow(base_testcase.clone(), exp_testcase.clone()) % modulus_testcase.clone();
+            let bn_test_res = base_testcase.clone().modpow(&exp_testcase, &modulus_testcase);
+            println!("testcase: (0x{})^(0x{}) mod 0x{} = 0x{}", base_testcase.clone().to_str_radix(16),
+                                        exp_testcase.clone().to_str_radix(16),
+                                        modulus_testcase.clone().to_str_radix(16),
+                                        bn_test_res.to_str_radix(16));
+            let base = base_testcase.clone();
+            let exp = exp_testcase.clone();
+            let modulus = modulus_testcase.clone();
+            let test_circuit = TestModExpCircuit{base, exp, modulus, bn_test_res} ;
+            let prover = match MockProver::run(16, &test_circuit, vec![]) {
+                Ok(prover_run) => prover_run,
+                Err(prover_error) => return Err(CircuitError::ProverError(prover_error)),
+            };
+            match prover.verify() {
+                Ok(_) => (),
+                Err(verifier_error) => return Err(CircuitError::VerifierError(verifier_error)),
+            };
+        }
         Ok(())
-
-
     }
-
-
-
 
     #[test]
     fn test_mod_power108m1_only() {
-        let output = run_mod_power108m1_circuit().expect("mod_power108m1_circuit failed prover verify");
-        println!("proof generation successful!\nresult: {:#?}", output);
+        let output = run_mod_power108m1_circuit().expect("\nmod_power108m1_circuit failed prover verify");
+        println!("\nproof generation successful!\nresult: {:#?}", output);
     }
 
     #[test]
     fn test_mod_power108m1_mul() {
-        let output = run_mod_power108m1_mul_circuit().expect("mod_power108m1_mul failed prover verify");
-        println!("proof generation successful!\nresult: {:#?}", output);
+        let output = run_mod_power108m1_mul_circuit().expect("\nmod_power108m1_mul failed prover verify");
+        println!("\nproof generation successful!\nresult: {:#?}", output);
     }
 
     #[test]
     fn test_mod_power216_mul() {
-        let output = run_mod_power216_mul_circuit().expect("run_mod_mult_circuit failed prover verify"); 
-        println!("proof generation successful!\nresult: {:#?}", output);
+        let output = run_mod_power216_mul_circuit().expect("\nrun_mod_mult_circuit failed prover verify"); 
+        println!("\nproof generation successful!\nresult: {:#?}", output);
     }
 
     #[test]
     fn test_mod_mult() {
-        let output = run_mod_mult_circuit().expect("run_mod_mult_circuit failed prover verify");
-        println!("proof generation successful!\nresult: {:#?}", output);
+        let output = run_mod_mult_circuit().expect("\nrun_mod_mult_circuit failed prover verify");
+        println!("\nproof generation successful!\nresult: {:#?}", output);
     }
 
     #[test]
     fn test_modexp() {
-        let output = run_modexp_circuit().expect("run_modexp_circuit failed prover verify");    //--> pass
-        println!("proof generation successful!\nresult: {:#?}", output);
+        let output = run_modexp_circuit().expect("\nrun_modexp_circuit failed prover verify");
+        println!("\nproof generation successful!\nresult: {:#?}", output);
     }
 
+    //------------------------------------------------------------
+    // test helpers:
+    use std::fmt;
+    use halo2_proofs::{
+        dev::{
+            VerifyFailure, 
+            FailureLocation,
+        },
+        plonk::Any,
+    };
+    
+    pub enum CircuitError {
+        /// Thrown when `MockProver::run` fails to prove the circuit.
+        ProverError(Error),
+        /// Thrown when verification fails.
+        VerifierError(Vec<VerifyFailure>),
+        /// Thrown when no operation has been specified.
+        NoOperation,
+    }
+    
+    impl fmt::Debug for CircuitError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                CircuitError::ProverError(prover_error) => {
+                    write!(f, "prover error in circuit: {}", prover_error)
+                }
+                CircuitError::VerifierError(verifier_error) => {
+                    write!(f, "verifier error in circuit: {:#?}", verifier_error)
+                }
+                CircuitError::NoOperation => {
+                    write!(f, "no operation is set (this should never happen.")
+                }
+            }
+        }
+    }
+
+    /// # bn_limbs from BigUint
+    /// Extracts BigUint to tuple of limbs \
+    /// BigUint -> (l2,l1,l0)
+    /// 
+    fn get_limbs_from_bn(bn: &BigUint) -> (BigUint, BigUint, BigUint) {
+        let limb0 = bn.modpow(&BigUint::from(1u128), &BigUint::from(1u128<<108));
+        let limb1 = ((bn - limb0.clone()) / BigUint::from(1u128<<108)).modpow(&BigUint::from(1u128), &BigUint::from(1u128<<108));
+        let limb2 = ((bn / BigUint::from(1u128<<108)))/(BigUint::from(1u128<<108));
+        (limb2, limb1, limb0)
+    }
+
+    /// # random BigUint x-bits long
+    /// returns a BigUint with bit length = bit_length 
+    /// 
+    fn get_random_x_bit_bn(bit_length: usize) -> BigUint {
+        let mut rng = thread_rng();
+        let mut b = BigUint::default();
+        while b.bits() != bit_length as u64 {
+            b = rng.sample(RandomBits::new(bit_length as u64));
+        }
+        b
+    }    
+
+    /// # random BigUint up to max x-bits long
+    /// returns a BigUint with bit length max max_bit_length 
+    /// 
+    fn get_random_bn(max_bit_length: usize) -> BigUint {
+        let bl = max_bit_length as u64;
+        let mut rng = thread_rng();
+        let mut b = BigUint::default();
+        b = rng.sample(RandomBits::new(bl));
+        b
+    }       
+
+    /// # Quick_and_Dirty BigUint exp function
+    /// base^exp = BigUint \
+    /// execution time = slow for exp > 16-bits
+    /// 
+    /// # Example
+    /// ```
+    /// let num: BigUint = big_pow(base, exp);
+    /// ```
+    fn big_pow(base: BigUint, exp: BigUint) -> BigUint
+    {
+        if exp == BigUint::from(0u128)
+        {
+            return BigUint::from(1u128);
+        }
+        let mut answer = base.clone();
+        let mut i = BigUint::from(1u128);
+        while i < exp
+        {
+            i = i + BigUint::from(1u128);
+            answer = answer * base.clone();
+        }
+        return answer;
+    }
+    //------------------------------------------------------------
 }
 


### PR DESCRIPTION
Corrected:
`mod_power216_mul()` to produce the correct mathematical result.

Test: 
```
cargo test --package zkwasm-host-circuits --lib -- circuits::modexp::tests::test_mod_power216_mul
```

Added:
Constraint for `mod_power216_zero`

Added:
Constraint in `circuits/mod.rs` to constrain all limbs to be either 1 or 0.

Adjusted:
5 test cases for:
`mod_power108m1()`,
`mod_power108m1_mul`,
`mod_power216_mul`,
`mod_mult()`,
`modexp()`,

Added:
1 test case for:
`mod_108m1_vs_216` checks x mod (2^108)-1) = x mod 2^216, for values < 2^108.

Acknowledge:
range checks still need to be checked, mod_mult still needs checking.

Test all:
```
cargo test --package zkwasm-host-circuits --lib -- circuits::modexp::tests
```