### PR TITLE
Yyu/configurable tree depth

### DIFF
--- a/src/circuits/merkle.rs
+++ b/src/circuits/merkle.rs
@@ -148,12 +148,12 @@ impl<F: FieldExt> MerkleChip<F> {
     }
 
 
-    fn assign_proof<const D: usize, M: MerkleTree<F, D>>(
+    fn assign_proof<const D: usize, M: MerkleTree<F>>(
         &self,
         region: &mut Region<F>,
         offset: &mut usize,
         _merkle: &M,
-        proof: &MerkleProof<F, D>,
+        proof: &MerkleProof<F>,
     ) -> Result<(), Error> {
         let mut index_offset = proof.index - (1u32 << D) - 1;
         let mut carry = proof.source;
@@ -180,23 +180,23 @@ impl<F: FieldExt> MerkleChip<F> {
         Ok(())
     }
 
-    pub fn assign_get<const D: usize, M: MerkleTree<F, D>>(
+    pub fn assign_get<const D: usize, M: MerkleTree<F>>(
         &self,
         region: &mut Region<F>,
         offset: &mut usize,
         merkle: &M,
-        proof: &MerkleProof<F, D>,
+        proof: &MerkleProof<F>,
     ) -> Result<(), Error> {
         self.assign_proof(region, offset, merkle, proof)
     }
 
-    pub fn assign_set<const D: usize, M: MerkleTree<F, D>>(
+    pub fn assign_set<const D: usize, M: MerkleTree<F>>(
         &self,
         region: &mut Region<F>,
         offset: &mut usize,
         merkle: &M,
-        proof_get: &MerkleProof<F, D>,
-        proof_set: &MerkleProof<F, D>,
+        proof_get: &MerkleProof<F>,
+        proof_set: &MerkleProof<F>,
     ) -> Result<(), Error> {
         self.assign_proof(region, offset, merkle, proof_get)?;
         self.assign_proof(region, offset, merkle, proof_set)


### PR DESCRIPTION
This one tested and passed for host module, by comment out all circuits related codes
<img width="892" alt="image" src="https://github.com/DelphinusLab/zkWasm-host-circuits/assets/22124307/82a5e595-f452-481e-91a3-6f6c46fbaaf4">


It changed the original hard code depth of trait MerkleTree to be configurable when construct the structure of MerkleTree/MerkleProof trait.

I haven't changed the circuits codes.
This is because:
1. I am not familair with circuits codes and looks like Xin is still changing it.
2. Looks like the MerkleChip need use the proof's depth info which assigned to it. However as we need change the MerkleTree/MerkleProof trait depth to be configurable, so we cannot know it from param's trait's generic define. Need read  it from instance passed in. So need talke with Xin.