### PR TITLE
Yyu/change to map or else

### DIFF
--- a/src/host/kvpair.rs
+++ b/src/host/kvpair.rs
@@ -523,9 +523,11 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_update() {
+    /* Tests cache hit
+     * Please note this test logic is to delete the records in DB for the second run and all depends on cache.
+     */
+    fn test_cache_hit() {
         for _ in 0..2 {
-            println!("Begin test -------------------------------");
             test_mongo_merkle_multi_leaves_update();
         }
     }

--- a/src/host/kvpair.rs
+++ b/src/host/kvpair.rs
@@ -471,18 +471,9 @@ mod tests {
         // 2
         let (mut leaf, _) = mt.get_leaf_with_proof(INDEX1).unwrap();
         leaf.set(&LEAF1_DATA.to_vec());
-        match mt.set_leaf_with_proof(&leaf) {
-            Ok(_) => {},
-            Err(error) => println!("set_leaf_with_proof error: {:?}", error),
-        };
+        mt.set_leaf_with_proof(&leaf).unwrap();
 
-        let (leaf, _) =  match mt.get_leaf_with_proof(INDEX1) {
-            Ok((leaf, p)) => {(leaf, p)},
-            Err(error) => {
-                println!("get_leaf_with_proof error: {:?}", error);
-                panic!("get_leaf_with_proof error: index {:?} error {:?}", INDEX1, error)
-            },
-        };
+        let (leaf, _) = mt.get_leaf_with_proof(INDEX1).unwrap();
 
         assert_eq!(leaf.index, INDEX1);
         assert_eq!(leaf.data, LEAF1_DATA);

--- a/src/host/merkle.rs
+++ b/src/host/merkle.rs
@@ -238,10 +238,10 @@ pub trait MerkleTree<H: Debug + Clone + PartialEq, const D: usize> {
         let hash = assist.to_vec().iter().fold(init, |acc, x| {
             let (left, right) = if p % 2 == 1 { (x, &acc) } else { (&acc, x) };
             p = p / 2;
-            println!("hash is {:?}", acc);
+            //println!("hash is {:?}", acc);
             Self::hash(left, right)
         });
-        println!("root {:?}", proof.root);
+        //println!("root {:?}", proof.root);
         Ok(proof.root == hash)
     }
 }


### PR DESCRIPTION
Fix bug for update_record.
Originally it was hidden because using map_or and it always evaluate default input so it do the update DB and cache every time.

The correct logic is to check the Option record is none or not. 

Previous wrong code is checking Result is error or OK and if OK, do nothing! (However, because map_or do the default input every time, so it just do update DB every time and make the code partially work, but do duplicate update when we have the record ....)