### PR TITLE
feat: Add gates for permute helper

### DIFF
--- a/src/adaptor/hashadaptor.rs
+++ b/src/adaptor/hashadaptor.rs
@@ -1,4 +1,5 @@
 use crate::circuits::poseidon::PoseidonChip;
+use crate::circuits::poseidon::PoseidonGateConfig;
 use crate::circuits::CommonGateConfig;
 use crate::circuits::LookupAssistChip;
 use crate::circuits::LookupAssistConfig;
@@ -61,13 +62,13 @@ fn hash_to_host_call_table(inputs: [Fr; 8], result: Fr) -> ExternalHostCallEntry
 const TOTAL_CONSTRUCTIONS: usize = 2048;
 
 impl HostOpSelector for PoseidonChip<Fr, 9, 8> {
-    type Config = CommonGateConfig;
+    type Config = (CommonGateConfig, PoseidonGateConfig);
     fn configure(meta: &mut ConstraintSystem<Fr>) -> Self::Config {
         PoseidonChip::<Fr, 9, 8>::configure(meta)
     }
 
     fn construct(c: Self::Config) -> Self {
-        PoseidonChip::construct(c, POSEIDON_HASHER_SPEC.clone())
+        PoseidonChip::construct(c.0, c.1, POSEIDON_HASHER_SPEC.clone())
     }
 
     fn assign(

--- a/src/adaptor/merkleadaptor.rs
+++ b/src/adaptor/merkleadaptor.rs
@@ -254,7 +254,7 @@ impl<const DEPTH: usize> HostOpSelector for MerkleChip<Fr, DEPTH> {
                         let (mut leaf, _) = mt
                             .as_ref()
                             .unwrap()
-                            .get_leaf_with_proof(arg_group[0].value.get_lower_128() as u32)
+                            .get_leaf_with_proof(arg_group[0].value.get_lower_128() as u64)
                             .expect("get leaf error");
                         leaf.set(
                             &data_to_bytes(vec![arg_group[2].value, arg_group[3].value]).to_vec(),
@@ -276,7 +276,7 @@ impl<const DEPTH: usize> HostOpSelector for MerkleChip<Fr, DEPTH> {
                         let (_, proof) = mt
                             .as_ref()
                             .unwrap()
-                            .get_leaf_with_proof(arg_group[0].value.get_lower_128() as u32)
+                            .get_leaf_with_proof(arg_group[0].value.get_lower_128() as u64)
                             .expect("get leaf error");
                         proof
                     };
@@ -319,7 +319,7 @@ mod tests {
         let index = 2_u64.pow(20) - 1;
         let data = Fr::from(0x1000 as u64);
         let mut mt = MongoMerkle::<20>::construct([0u8; 32], DEFAULT_HASH_VEC[20].clone());
-        let (mut leaf, _) = mt.get_leaf_with_proof(index as u32).unwrap();
+        let (mut leaf, _) = mt.get_leaf_with_proof(index).unwrap();
         let bytesdata = field_to_bytes(&data).to_vec();
         println!("bytes_data is {:?}", bytesdata);
         leaf.set(&bytesdata);
@@ -343,7 +343,7 @@ mod tests {
         let data = Fr::from(0x1000 as u64);
 
         let mut mt = MongoMerkle::<20>::construct([0u8; 32], DEFAULT_HASH_VEC[20].clone());
-        let (mut leaf, _) = mt.get_leaf_with_proof(index as u32).unwrap();
+        let (mut leaf, _) = mt.get_leaf_with_proof(index).unwrap();
         let bytesdata = field_to_bytes(&data).to_vec();
         println!("bytes_data is {:?}", bytesdata);
         leaf.set(&bytesdata);

--- a/src/adaptor/merkleadaptor.rs
+++ b/src/adaptor/merkleadaptor.rs
@@ -10,6 +10,7 @@ use halo2_proofs::plonk::Error;
 
 use crate::circuits::merkle::MerkleChip;
 use crate::circuits::CommonGateConfig;
+use crate::circuits::poseidon::PoseidonGateConfig;
 
 use crate::circuits::host::{HostOpConfig, HostOpSelector};
 
@@ -60,13 +61,13 @@ fn kvpair_to_host_call_table(
 }
 
 impl<const DEPTH: usize> HostOpSelector for MerkleChip<Fr, DEPTH> {
-    type Config = CommonGateConfig;
+    type Config = (CommonGateConfig, PoseidonGateConfig);
     fn configure(meta: &mut ConstraintSystem<Fr>) -> Self::Config {
         MerkleChip::<Fr, DEPTH>::configure(meta)
     }
 
     fn construct(c: Self::Config) -> Self {
-        MerkleChip::new(c)
+        MerkleChip::new(c.0, c.1)
     }
 
     fn assign(

--- a/src/adaptor/merkleadaptor.rs
+++ b/src/adaptor/merkleadaptor.rs
@@ -227,10 +227,6 @@ impl<const DEPTH: usize> HostOpSelector for MerkleChip<Fr, DEPTH> {
             |mut region| {
                 let mut offset = 0;
                 let mut round = 0;
-                const DEFAULT_ROOT_HASH_BYTES: [u8; 32] = [
-                    73, 83, 87, 90, 86, 12, 245, 204, 26, 115, 174, 210, 71, 149, 39, 167, 187, 3,
-                    97, 202, 100, 149, 65, 101, 59, 11, 239, 93, 150, 126, 33, 11,
-                ];
 
                 let config = self.config.clone();
                 self.initialize(&config, &mut region, &mut offset)?;
@@ -312,13 +308,14 @@ mod tests {
     use crate::utils::field_to_bytes;
     use halo2_proofs::pairing::bn256::Fr;
     use std::fs::File;
+    use crate::MERKLE_DEPTH;
 
     #[test]
     fn generate_kvpair_input_get_set() {
-        let root_default = Fr::from_raw(bytes_to_u64(&DEFAULT_HASH_VEC[20]));
-        let index = 2_u64.pow(20) - 1;
+        let root_default = Fr::from_raw(bytes_to_u64(&DEFAULT_HASH_VEC[MERKLE_DEPTH]));
+        let index = 2_u64.pow(MERKLE_DEPTH as u32) - 1;
         let data = Fr::from(0x1000 as u64);
-        let mut mt = MongoMerkle::<20>::construct([0u8; 32], DEFAULT_HASH_VEC[20].clone());
+        let mut mt = MongoMerkle::<MERKLE_DEPTH>::construct([0u8; 32], DEFAULT_HASH_VEC[MERKLE_DEPTH].clone());
         let (mut leaf, _) = mt.get_leaf_with_proof(index).unwrap();
         let bytesdata = field_to_bytes(&data).to_vec();
         println!("bytes_data is {:?}", bytesdata);
@@ -338,11 +335,11 @@ mod tests {
 
     #[test]
     fn generate_kvpair_input_gets_set() {
-        let root_default = Fr::from_raw(bytes_to_u64(&DEFAULT_HASH_VEC[20]));
-        let index = 2_u64.pow(20) - 1;
+        let root_default = Fr::from_raw(bytes_to_u64(&DEFAULT_HASH_VEC[MERKLE_DEPTH]));
+        let index = 2_u64.pow(MERKLE_DEPTH as u32) - 1;
         let data = Fr::from(0x1000 as u64);
 
-        let mut mt = MongoMerkle::<20>::construct([0u8; 32], DEFAULT_HASH_VEC[20].clone());
+        let mut mt = MongoMerkle::<MERKLE_DEPTH>::construct([0u8; 32], DEFAULT_HASH_VEC[MERKLE_DEPTH].clone());
         let (mut leaf, _) = mt.get_leaf_with_proof(index).unwrap();
         let bytesdata = field_to_bytes(&data).to_vec();
         println!("bytes_data is {:?}", bytesdata);

--- a/src/adaptor/merkleadaptor.rs
+++ b/src/adaptor/merkleadaptor.rs
@@ -30,7 +30,7 @@ const MERGE_SIZE: usize = 4;
 const MERGE_DATA_SIZE: usize = 2;
 // 0: set/get 1-4: root 5-8:address 9-12:value
 const CHUNK_SIZE: usize = 1 + 1 * MERGE_SIZE + 1 * MERGE_SIZE; // should equal to 9
-const TOTAL_CONSTRUCTIONS: usize = 128;
+const TOTAL_CONSTRUCTIONS: usize = 800;
 
 fn kvpair_new(address: u64) -> Vec<ExternalHostCallEntry> {
     vec![ExternalHostCallEntry {

--- a/src/circuits/merkle.rs
+++ b/src/circuits/merkle.rs
@@ -13,7 +13,7 @@ use crate::circuits::Limb;
 use crate::host::merkle::MerkleProof;
 use crate::host::poseidon::MERKLE_HASHER_SPEC;
 use crate::host::poseidon::POSEIDON_HASHER_SPEC;
-use crate::host::ForeignInst::KVPairSet;
+use crate::host::ForeignInst::MerkleSet;
 use halo2_proofs::pairing::bn256::Fr;
 
 /* Given a merkel tree eg1 with height=3:
@@ -115,7 +115,7 @@ impl<const D: usize> MerkleChip<Fr, D> {
             &mut (),
             offset,
             opcode,
-            &Fr::from(KVPairSet as u64),
+            &Fr::from(MerkleSet as u64),
         )?;
         let fills = proof
             .assist

--- a/src/circuits/merkle.rs
+++ b/src/circuits/merkle.rs
@@ -164,6 +164,7 @@ impl<const D: usize> MerkleChip<Fr, D> {
         //println!("offset for position is: {:?}", c.value);
         self.config
             .decompose_limb(region, &mut (), offset, &c, &mut positions, D)?;
+
         // position = 0 means assist is at right else assist is at left
         let initial_hash = self.data_hasher_chip.get_permute_result(
             region,

--- a/src/circuits/mod.rs
+++ b/src/circuits/mod.rs
@@ -189,6 +189,7 @@ impl CommonGateConfig {
         limbs: &mut Vec<Limb<F>>,
         limbsizeraw: usize,
     ) -> Result<(), Error> {
+        let initsize = limbs.len();
         let limbsize = (limbsizeraw + 3) & (!3);
         let mut bool_limbs = field_to_bn(&limb.value).to_radix_le(2);
         bool_limbs.truncate(limbsize);
@@ -297,7 +298,7 @@ impl CommonGateConfig {
             )?;
         }
 
-        limbs.truncate(limbsizeraw);
+        limbs.truncate(initsize + limbsizeraw);
         Ok(())
     }
 

--- a/src/circuits/mod.rs
+++ b/src/circuits/mod.rs
@@ -27,9 +27,9 @@ use halo2_proofs::{
  * lookup_ind: whether perform lookup at this line
  */
 #[rustfmt::skip]
-customized_circuits!(CommonGateConfig, 2, 5, 12, 0,
-    | l0  | l1   | l2  | l3  | d   |  c0  | c1  | c2  | c3  | cd  | cdn | c   | c03  | c12  | lookup_hint | lookup_ind  | sel
-    | nil | nil  | nil | nil | d_n |  nil | nil | nil | nil | nil | nil | nil | nil  | nil  | nil         | nil         | nil
+customized_circuits!(CommonGateConfig, 2, 5, 13, 0,
+    | l0   | l1    | l2   | l3   | d   |  c0  | c1  | c2  | c3  | cd  | cdn | c   | c03  | c12  | lookup_hint | lookup_ind  | common_sel | permute_sel 
+    | l0_n | l1_n  | l2_n | nil  | d_n |  nil | nil | nil | nil | nil | nil | nil | nil  | nil  | nil         | nil         |    nil     |      nil
 );
 pub trait LookupAssistConfig {
     /// register a column (col) to be range checked by limb size (sz)
@@ -79,7 +79,7 @@ impl CommonGateConfig {
     ) -> Self {
         let witness = [0; 5].map(|_| cs.advice_column());
         witness.map(|x| cs.enable_equality(x));
-        let fixed = [0; 12].map(|_| cs.fixed_column());
+        let fixed = [0; 13].map(|_| cs.fixed_column());
         let selector = [];
 
         let config = CommonGateConfig {
@@ -97,6 +97,36 @@ impl CommonGateConfig {
             |c| config.get_expr(c, CommonGateConfig::lookup_hint()),
         );
 
+        cs.create_gate("poseidon-2 permute helper constraint", |meta| {
+            let x0 = config.get_expr(meta, CommonGateConfig::l0());
+            let x1 = config.get_expr(meta, CommonGateConfig::l1());
+            let x2 = config.get_expr(meta, CommonGateConfig::l2());
+            let x0_2 = config.get_expr(meta, CommonGateConfig::l3());
+            let x0_5_c = config.get_expr(meta, CommonGateConfig::d());
+
+            let x0_next = config.get_expr(meta, CommonGateConfig::l0_n());
+            let x1_next = config.get_expr(meta, CommonGateConfig::l1_n());
+            let x2_next = config.get_expr(meta, CommonGateConfig::l2_n());
+
+            let c = config.get_expr(meta, CommonGateConfig::cd());
+            let c0 = config.get_expr(meta, CommonGateConfig::c0());
+            let c1 = config.get_expr(meta, CommonGateConfig::c1());
+            let c2 = config.get_expr(meta, CommonGateConfig::c2());
+            let e1 = config.get_expr(meta, CommonGateConfig::c3());
+            let e2 = config.get_expr(meta, CommonGateConfig::c());
+
+            let sel = config.get_expr(meta, CommonGateConfig::permute_sel());
+
+            vec![
+                sel.clone() * (x0.clone() * x0.clone() - x0_2.clone()),
+                sel.clone() * (x0_2.clone() * x0_2.clone() * x0 + c - x0_5_c.clone()),
+                sel.clone() * (x0_next - (x0_5_c.clone() * c0 + x1.clone() * c1 + x2.clone() * c2)),
+                sel.clone() * (x1_next - (x0_5_c.clone() * e1 + x1)),
+                sel.clone() * (x2_next - (x0_5_c * e2 + x2)),
+            ]
+        });
+
+        // helper gates for implementing poseidon with 2 cell permute
         cs.create_gate("one line constraint", |meta| {
             let l0 = config.get_expr(meta, CommonGateConfig::l0());
             let l1 = config.get_expr(meta, CommonGateConfig::l1());
@@ -113,7 +143,7 @@ impl CommonGateConfig {
             let cdn = config.get_expr(meta, CommonGateConfig::cdn());
             let c03 = config.get_expr(meta, CommonGateConfig::c03());
             let c12 = config.get_expr(meta, CommonGateConfig::c12());
-            let sel = config.get_expr(meta, CommonGateConfig::sel());
+            let sel = config.get_expr(meta, CommonGateConfig::common_sel());
 
             // if odd then carry is put at right else put at left
             vec![
@@ -342,6 +372,89 @@ impl CommonGateConfig {
         Ok(limbs)
     }
 
+    fn assign_permute_helper_line<F: FieldExt, const RATE: usize, const T: usize>(
+        &self,
+        region: &mut Region<F>,
+        offset: &mut usize,
+        state: &mut [Limb<F>; T],
+        x5_c_v: F,
+        c_v: [F; T],
+        e_v: [F; RATE],
+        is_first_line: bool,
+        is_last_line: bool,
+    ) -> Result<(), Error> {
+        // currently only supports (2, 3)
+        assert!(RATE == 2);
+        assert!(T == 3);
+
+        let x = [Self::l0(), Self::l1(), Self::l2()];
+        let x0_2 = Self::l3();
+        let x0_5_c = Self::d();
+
+        let x5_c = CommonGateConfig::cd();
+        let c = [
+            CommonGateConfig::c0(),
+            CommonGateConfig::c1(),
+            CommonGateConfig::c2(),
+        ];
+        let e = [CommonGateConfig::c3(), CommonGateConfig::c()];
+
+        self.assign_cell(region, *offset, &CommonGateConfig::permute_sel(), F::one())?;
+
+        // assign constants
+        for i in 0..RATE {
+            self.assign_cell(region, *offset, &e[i], e_v[i])?;
+        }
+
+        for i in 0..T {
+            self.assign_cell(region, *offset, &c[i], c_v[i])?;
+        }
+
+        self.assign_cell(region, *offset, &x5_c, x5_c_v)?;
+
+        // assign current states
+        // only assign state at the 1st line of a permute block
+        if is_first_line {
+            for i in 0..T {
+                let x = self.assign_cell(region, *offset, &x[i], state[i].value)?;
+                region.constrain_equal(x.get_the_cell().cell(), state[i].get_the_cell().cell())?;
+            }
+        }
+
+        // assign current states aux
+        let x0_2 = self.assign_cell(region, *offset, &x0_2, state[0].value.square())?;
+        let x0_5_c = self.assign_cell(
+            region,
+            *offset,
+            &x0_5_c,
+            x0_2.value.square() * state[0].value + x5_c_v,
+        )?;
+
+        // assign next states
+        state[0] = self.assign_cell(
+            region,
+            *offset + 1,
+            &x[0],
+            x0_5_c.value * c_v[0] + state[1].value * c_v[1] + state[2].value * c_v[2],
+        )?;
+        for i in 1..T {
+            state[i] = self.assign_cell(
+                region,
+                *offset + 1,
+                &x[i],
+                x0_5_c.value * e_v[i - 1] + state[i].value,
+            )?;
+        }
+
+        if is_last_line {
+            *offset = *offset + 2;
+        } else {
+            *offset = *offset + 1;
+        }
+
+        Ok(())
+    }
+
     fn assign_line<F: FieldExt, LC: LookupAssistChip<F>>(
         &self,
         region: &mut Region<F>,
@@ -395,7 +508,7 @@ impl CommonGateConfig {
             let v = coeffs[i].as_ref().map_or(F::zero(), |x| *x);
             self.assign_cell(region, *offset, &COMMON_CS[i], v).unwrap();
         }
-        self.assign_cell(region, *offset, &CommonGateConfig::sel(), F::one())?;
+        self.assign_cell(region, *offset, &CommonGateConfig::common_sel(), F::one())?;
         self.assign_cell(
             region,
             *offset,

--- a/src/circuits/mod.rs
+++ b/src/circuits/mod.rs
@@ -187,12 +187,14 @@ impl CommonGateConfig {
         offset: &mut usize,
         limb: &Limb<F>,
         limbs: &mut Vec<Limb<F>>,
-        limbsize: usize,
+        limbsizeraw: usize,
     ) -> Result<(), Error> {
+        let limbsize = (limbsizeraw + 3) & (!3);
         let mut bool_limbs = field_to_bn(&limb.value).to_radix_le(2);
         bool_limbs.truncate(limbsize);
         bool_limbs.resize_with(limbsize, || 0);
         bool_limbs.reverse();
+        //FIXME: ensure the first v is zero
         let mut v = F::zero();
         for i in 0..(limbsize / 4) {
             let l0 = F::from_u128(bool_limbs[4 * i] as u128);
@@ -232,6 +234,7 @@ impl CommonGateConfig {
             limbs.append(&mut l.to_vec()[0..4].to_vec());
             v = v_next;
         }
+
         // constraint that limb.value is equal v_next so that the above limbs is
         // a real decompose of the limb.value
         self.assign_line(
@@ -294,6 +297,7 @@ impl CommonGateConfig {
             )?;
         }
 
+        limbs.truncate(limbsizeraw);
         Ok(())
     }
 

--- a/src/host/cache.rs
+++ b/src/host/cache.rs
@@ -14,6 +14,6 @@ lazy_static::lazy_static! {
         ));
 }
 
-pub fn get_cache_key(cname: String, index: u32, hash: &[u8; 32]) -> String {
+pub fn get_cache_key(cname: String, index: u64, hash: &[u8; 32]) -> String {
     cname + &index.to_string() + &hex::encode(hash)
 }

--- a/src/host/cache.rs
+++ b/src/host/cache.rs
@@ -1,4 +1,4 @@
-use crate::host::kvpair::MerkleRecord;
+use crate::host::mongomerkle::MerkleRecord;
 use lru::LruCache;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;

--- a/src/host/datahash.rs
+++ b/src/host/datahash.rs
@@ -102,10 +102,13 @@ impl MongoDataHash {
         r.map_or_else(
             || {
                 //println!("Do update record to DB for hash: {:?}", record.hash);
-                collection.insert_one(record, None)?;
+                collection.insert_one(record.clone(), None)?;
                 Ok(())
             },
-            |_| Ok(()),
+            |bytes| {
+                assert_eq!(record.data, bytes.data);
+                Ok(())
+            },
         )
     }
 }

--- a/src/host/datahash.rs
+++ b/src/host/datahash.rs
@@ -114,10 +114,10 @@ impl MongoDataHash {
 pub struct DataHashRecord {
     #[serde(serialize_with = "self::serialize_bytes_as_binary")]
     #[serde(deserialize_with = "self::deserialize_u256_from_binary")]
-    hash: [u8; 32],
+    pub hash: [u8; 32],
     #[serde(serialize_with = "self::serialize_bytes_as_binary")]
     #[serde(deserialize_with = "self::deserialize_bytes_from_binary")]
-    data: Vec<u8>,
+    pub data: Vec<u8>,
 }
 
 impl DataHashRecord {

--- a/src/host/datahash.rs
+++ b/src/host/datahash.rs
@@ -1,0 +1,154 @@
+use crate::host::db;
+use ff::PrimeField;
+use halo2_proofs::pairing::bn256::Fr;
+//use lazy_static;
+use mongodb::bson::doc;
+use mongodb::bson::{spec::BinarySubtype, Bson};
+use crate::host::poseidon::POSEIDON_HASHER;
+use serde::{
+    de::{Error, Unexpected},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+fn deserialize_u256_from_binary<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Bson::deserialize(deserializer) {
+        Ok(Bson::Binary(bytes)) => Ok(bytes.bytes.try_into().unwrap()),
+        Ok(..) => Err(Error::invalid_value(Unexpected::Enum, &"Bson::Binary")),
+        Err(e) => Err(e),
+    }
+}
+
+fn deserialize_bytes_from_binary<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Bson::deserialize(deserializer) {
+        Ok(Bson::Binary(bytes)) => Ok(bytes.bytes.to_vec()),
+        Ok(..) => Err(Error::invalid_value(Unexpected::Enum, &"Bson::Binary")),
+        Err(e) => Err(e),
+    }
+}
+
+fn serialize_bytes_as_binary<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let binary = Bson::Binary(mongodb::bson::Binary {
+        subtype: BinarySubtype::Generic,
+        bytes: bytes.into(),
+    });
+    binary.serialize(serializer)
+}
+
+/*
+fn hash_to_bson(x: &[u8; 32]) -> Bson {
+    Bson::Binary(mongodb::bson::Binary {
+        subtype: BinarySubtype::Generic,
+        bytes: (*x).into(),
+    })
+}
+*/
+
+#[derive(Debug)]
+pub struct MongoDataHash {
+    contract_address: [u8; 32],
+}
+
+impl PartialEq for DataHashRecord {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash
+    }
+    fn ne(&self, other: &Self) -> bool {
+        !self.eq(other)
+    }
+}
+
+impl MongoDataHash {
+    fn get_collection_name(&self) -> String {
+        format!("DATAHASH_{}", hex::encode(&self.contract_address))
+    }
+    fn get_db_name() -> String {
+        return "zkwasm-mongo-merkle".to_string();
+    }
+
+    pub fn construct(addr: [u8; 32]) -> Self {
+        MongoDataHash {
+            contract_address: addr,
+        }
+    }
+
+    pub fn get_record(
+        &self,
+        hash: &[u8; 32],
+    ) -> Result<Option<DataHashRecord>, mongodb::error::Error> {
+        let dbname = Self::get_db_name();
+        let cname = self.get_collection_name();
+        let collection = db::get_collection::<DataHashRecord>(dbname, cname)?;
+        let mut filter = doc! {};
+        filter.insert("hash", db::u256_to_bson(hash));
+        let record = collection.find_one(filter, None);
+        record
+    }
+
+    /* We always insert new record as there might be uncommitted update to the merkle tree */
+    pub fn update_record(&self, record: DataHashRecord) -> Result<(), mongodb::error::Error> {
+        let dbname = Self::get_db_name();
+        let cname = self.get_collection_name();
+        let collection = db::get_collection::<DataHashRecord>(dbname, cname.clone())?;
+        let r: Option<DataHashRecord> = self.get_record(&record.hash)?;
+        r.map_or_else(
+            || {
+                //println!("Do update record to DB for hash: {:?}", record.hash);
+                collection.insert_one(record, None)?;
+                Ok(())
+            },
+            |_| Ok(()),
+        )
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DataHashRecord {
+    #[serde(serialize_with = "self::serialize_bytes_as_binary")]
+    #[serde(deserialize_with = "self::deserialize_u256_from_binary")]
+    hash: [u8; 32],
+    #[serde(serialize_with = "self::serialize_bytes_as_binary")]
+    #[serde(deserialize_with = "self::deserialize_bytes_from_binary")]
+    data: Vec<u8>,
+}
+
+impl DataHashRecord {
+    pub fn new(&mut self, data: &Vec<u8>) -> Self {
+        let mut hasher = POSEIDON_HASHER.clone();
+        let batchdata = data
+            .chunks(16)
+            .into_iter()
+            .map(|x| {
+                let mut v = x.clone().to_vec();
+                v.extend_from_slice(&[0u8; 16]);
+                let f = v.try_into().unwrap();
+                Fr::from_repr(f).unwrap()
+            })
+            .collect::<Vec<Fr>>();
+        hasher.update(&batchdata.as_slice());
+        DataHashRecord {
+            data: data.clone().try_into().unwrap(),
+            hash: hasher.squeeze().to_repr()
+        }
+    }
+    pub fn data_as_u64(&self) -> [u64; 4] {
+        [
+            u64::from_le_bytes(self.data[0..8].try_into().unwrap()),
+            u64::from_le_bytes(self.data[8..16].try_into().unwrap()),
+            u64::from_le_bytes(self.data[16..24].try_into().unwrap()),
+            u64::from_le_bytes(self.data[24..32].try_into().unwrap()),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+}

--- a/src/host/db.rs
+++ b/src/host/db.rs
@@ -3,6 +3,8 @@ use mongodb::{
     sync::{Client, Collection},
 };
 
+use mongodb::bson::{spec::BinarySubtype, Bson};
+
 const MONGODB_URI: &str = "mongodb://localhost:27017";
 
 lazy_static::lazy_static! {
@@ -17,3 +19,12 @@ pub fn get_collection<T>(
     let collection = database.collection::<T>(name.as_str());
     Ok(collection)
 }
+
+pub fn u256_to_bson(x: &[u8; 32]) -> Bson {
+    Bson::Binary(mongodb::bson::Binary {
+        subtype: BinarySubtype::Generic,
+        bytes: (*x).into(),
+    })
+}
+
+

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -7,6 +7,7 @@ pub mod mongomerkle;
 pub mod merkle;
 pub mod poseidon;
 pub mod rmd160;
+pub mod datahash;
 
 use halo2_proofs::arithmetic::FieldExt;
 use serde::{Deserialize, Serialize};

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -44,6 +44,8 @@ pub enum ForeignInst {
     MerkleAddress, // 13
     MerkleSet,     // 14
     MerkleGet,     // 15
+    MerklePutData,  // 16
+    MerkleFetchData, // 17
     SHA256New,
     SHA256Push,
     SHA256Finalize,

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -3,7 +3,7 @@ pub mod bn256;
 pub mod cache;
 pub mod db;
 pub mod jubjub;
-pub mod kvpair;
+pub mod mongomerkle;
 pub mod merkle;
 pub mod poseidon;
 pub mod rmd160;
@@ -38,11 +38,11 @@ pub enum ForeignInst {
     Bn254SumScalar,
     Bn254SumG1,
     Bn254SumResult,
-    KVPairSetRoot, // 11
-    KVPairGetRoot, // 12
-    KVPairAddress, // 13
-    KVPairSet,     // 14
-    KVPairGet,     // 15
+    MerkleSetRoot, // 11
+    MerkleGetRoot, // 12
+    MerkleAddress, // 13
+    MerkleSet,     // 14
+    MerkleGet,     // 15
     SHA256New,
     SHA256Push,
     SHA256Finalize,

--- a/src/host/mongomerkle.rs
+++ b/src/host/mongomerkle.rs
@@ -160,7 +160,6 @@ impl<const DEPTH: usize> MongoMerkle<DEPTH> {
 
             while let Some(record) = cursor.next() {
                 let r = record.unwrap();
-                println!("find in db only{:?}", r.index);
                 find.push(r.clone());
                 find_in_db_only.push(r.clone());
                 notfind.remove(notfind.iter().position(|x| x.clone() == r.clone()).unwrap());

--- a/src/host/mongomerkle.rs
+++ b/src/host/mongomerkle.rs
@@ -102,7 +102,7 @@ impl<const DEPTH: usize> MongoMerkle<DEPTH> {
         format!("MERKLEDATA_{}", hex::encode(&self.contract_address))
     }
     fn get_db_name() -> String {
-        return "zkwasmkvpair".to_string();
+        return "zkwasm-mongo-merkle".to_string();
     }
 
     pub fn get_record(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod adaptor;
 pub mod circuits;
 pub mod host;
 pub mod utils;
+pub const MERKLE_DEPTH: usize = 32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod adaptor;
 pub mod circuits;
 pub mod host;
 pub mod utils;
+pub const MERKLE_DEPTH: usize = 32;
 
 /*
 use crate::{
@@ -261,13 +262,13 @@ fn main() {
             prover.create_proof(cache_folder.as_path(), k);
         }
         OpType::MERKLE => {
-            let merkle_circuit = HostOpCircuit::<Fr, MerkleChip<Fr, 20>> {
+            let merkle_circuit = HostOpCircuit::<Fr, MerkleChip<Fr, MERKLE_DEPTH>> {
                 shared_operands,
                 shared_opcodes,
                 shared_index,
                 _marker: PhantomData,
             };
-            let prover: HostCircuitInfo<Bn256, HostOpCircuit<Fr, MerkleChip<Fr, 20>>> =
+            let prover: HostCircuitInfo<Bn256, HostOpCircuit<Fr, MerkleChip<Fr, MERKLE_DEPTH>>> =
                 HostCircuitInfo::new(merkle_circuit, format!("{:?}", opname), vec![]);
             prover.mock_proof(k);
             prover.create_proof(cache_folder.as_path(), k);


### PR DESCRIPTION
Currently, the permute of poseion(2, 3) spends 300+ rows on partial round (about 6 rows / round). The PR uses a helper gate to make it 1 row/round. It can increase the merkle tree capacity while only involves one addition fixed columns.