### PR TITLE
Xgao/refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,5 @@ perf = ["circuits-batcher/perf"]
 mongo-std-sync = ["mongodb/sync"]
 mongo-tokio-sync = ["mongodb/tokio-sync"]
 cuda = ["halo2_proofs/cuda"]
-complex-leaf = []
 profile = ["ark-std/print-trace", "halo2_proofs/profile", "circuits-batcher/profile"]
 

--- a/src/circuits/host.rs
+++ b/src/circuits/host.rs
@@ -154,6 +154,7 @@ impl HostOpConfig {
         indicator: Fr,
         enable: bool,
     ) -> Result<(Limb<Fr>, Limb<Fr>), Error> {
+        /* values = [v0, v1, v2] in little endian */
         let mut rev = values.clone();
         let len = values.len();
         rev.reverse();

--- a/src/host/merkle.rs
+++ b/src/host/merkle.rs
@@ -259,6 +259,8 @@ pub trait MerkleTree<H: Debug + Clone + PartialEq, const D: usize> {
                     .map(|x| acc_node.descendant(get_sibling_index(*x) as usize - 1).unwrap())
                     .collect::<Vec<_>>();
 
+                println!("primary hash {:?}", primary_hashs);
+
                 let last_hash = primary_hashs.last().unwrap();
                 let height = nodes.len() * Self::chunk_depth();
                 let acc_node = self.get_node_with_hash(height as u64, last_hash).unwrap();

--- a/src/host/merkle.rs
+++ b/src/host/merkle.rs
@@ -499,6 +499,19 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_path() {
+        assert_eq!(get_path(0), vec![] as Vec<u64>);
+        assert_eq!(get_path(1), vec![1]);
+        assert_eq!(get_path(2), vec![2]);
+        assert_eq!(get_path(3), vec![1,3]);
+        assert_eq!(get_path(4), vec![1,4]);
+        assert_eq!(get_path(5), vec![2,5]);
+        assert_eq!(get_path(6), vec![2,6]);
+        assert_eq!(get_path(7), vec![1,3,7]);
+    }
+
+
 
     #[test]
     fn test_merkle_path() {

--- a/src/host/merkle.rs
+++ b/src/host/merkle.rs
@@ -234,6 +234,7 @@ pub trait MerkleTree<H: Debug + Clone + PartialEq, const D: usize> {
     ) -> Result<(Vec<Self::Node>, MerkleProof<H, D>), MerkleError> {
         self.leaf_check(index)?;
         let paths = self.get_path_binary(index)?.to_vec();
+        let index_paths = self.get_path(index)?.to_vec();
         println!("paths is {:?}", paths);
         assert!((paths.len() % Self::chunk_depth()) == 0);
         let mut path_chunks = paths.chunks_exact(Self::chunk_depth()).collect::<Vec<&[u64]>>();
@@ -263,7 +264,9 @@ pub trait MerkleTree<H: Debug + Clone + PartialEq, const D: usize> {
 
                 let last_hash = primary_hashs.last().unwrap();
                 let height = nodes.len() * Self::chunk_depth();
-                let acc_node = self.get_node_with_hash(height as u64, last_hash).unwrap();
+                let index = index_paths[height - 1];
+                println!("index is {}", index);
+                let acc_node = self.get_node_with_hash(index as u64, last_hash).unwrap();
                 nodes.push(acc_node);
                 assist.append(&mut sibling_hashs);
                 (assist, nodes)

--- a/src/host/mongomerkle.rs
+++ b/src/host/mongomerkle.rs
@@ -141,7 +141,6 @@ impl<const DEPTH: usize> MongoMerkle<DEPTH> {
     }
 
     pub fn generate_default_node(&self, index: u64) -> Result<MerkleRecord, MerkleError> {
-        println!("generate default node {}", index);
         let height = (index + 1).ilog2() as usize;
         let default_hash = if height < Self::height() {
             Some(self.get_node_default_hash(height as usize))

--- a/src/host/mongomerkle.rs
+++ b/src/host/mongomerkle.rs
@@ -122,6 +122,9 @@ impl<const DEPTH: usize> MongoMerkle<DEPTH> {
 
     //the input records must be in one leaf path
     pub fn update_records(&mut self, records: &Vec<MerkleRecord>) -> Result<(), anyhow::Error> {
+        for r in records.iter() {
+            println!("update record: {:?}", r.hash());
+        }
         self.db.borrow_mut().set_merkle_records(records)?;
         Ok(())
     }
@@ -173,10 +176,8 @@ impl<const DEPTH: usize> MongoMerkle<DEPTH> {
     ) -> Result<MerkleRecord, MerkleError> {
         let height = (index + 1).ilog2() as usize;
         assert!(height <= Self::height());
-
         let default_hash = self.get_default_hash(height)?;
         if &default_hash == hash {
-            println!("generate default node");
             self.generate_default_node(index)
         } else {
             match self.get_record(hash) {
@@ -296,7 +297,7 @@ impl MerkleNode<[u8; 32]> for MerkleRecord {
         }
         let index = offset + 1;
         let height = (index + 1).ilog2() as usize;
-        println!("offset is {} {}", offset, height);
+        println!("offset is {} {} {}", offset, height, self.descendants.len());
         return self.default_hash.map(
             |d| d[height - 1]
         );

--- a/src/host/mongomerkle.rs
+++ b/src/host/mongomerkle.rs
@@ -122,9 +122,11 @@ impl<const DEPTH: usize> MongoMerkle<DEPTH> {
 
     //the input records must be in one leaf path
     pub fn update_records(&mut self, records: &Vec<MerkleRecord>) -> Result<(), anyhow::Error> {
+        /*
         for r in records.iter() {
             println!("update record: {:?}", r.hash());
         }
+        */
         self.db.borrow_mut().set_merkle_records(records)?;
         Ok(())
     }
@@ -297,7 +299,7 @@ impl MerkleNode<[u8; 32]> for MerkleRecord {
         }
         let index = offset + 1;
         let height = (index + 1).ilog2() as usize;
-        println!("offset is {} {} {}", offset, height, self.descendants.len());
+        //println!("offset is {} {} {}", offset, height, self.descendants.len());
         return self.default_hash.map(
             |d| d[height - 1]
         );


### PR DESCRIPTION
Try to improve the performance of Merkle lookup and update by caching multiple nodes as a subtree in one Mongo DB record.
