### PR TITLE
fix host circuit for bn256 or bls381 pairing case

### DIFF
--- a/src/adaptor/bn256adaptor.rs
+++ b/src/adaptor/bn256adaptor.rs
@@ -267,6 +267,7 @@ impl HostOpSelector for Bn256PairChip<Fr> {
 
         let total_avail_rounds = Self::max_rounds(k);
 
+        // not real filter operands, set enable to false.
         for _ in 0..total_avail_rounds - total_used_instructions {
             // get g1_x and g1_y: ((1,1) (1,1) 1) * 2
             for j in 0..2 {

--- a/src/circuits/host.rs
+++ b/src/circuits/host.rs
@@ -139,9 +139,16 @@ impl HostOpConfig {
             let sel_n = self.get_expr(meta, HostOpConfig::sel_n());
             let enable = self.get_expr(meta, HostOpConfig::enable());
             let filtered_index = self.get_expr(meta, HostOpConfig::filtered_index());
+            let filtered_index_n = self.get_expr(meta, HostOpConfig::filtered_index_n());
             vec![
-                sel.clone() * (constant_from!(1 as u64) - enable.clone()) * filtered_index,
-                sel * (sel_n - constant_from!(1 as u64)) * enable,
+                // filter index is true(length..1), enable should also be true
+                sel.clone() * (constant_from!(1 as u64) - enable) * filtered_index,
+                // filtered_index_n is true, sel_n should also be true
+                // but if filtered_index or enable is true, sel_n may not be true(like as bn256 pairing end)
+                // if filtered_index_n is not true(end filtered), sel is not care.
+                // here enable_n is equivalent with filtered_index_n as previous constrain that
+                // enable always should be true when filter index is true. filtered_index_n is more direct than enable_n
+                sel * (sel_n - constant_from!(1 as u64)) * filtered_index_n,
             ]
         });
     }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -173,6 +173,7 @@ pub fn exec_create_host_proof(
                 ProofPieceInfo::new(format!("{}.{:?}", name, opname), 0, 0, None);
             let mut proof_gen_info =
                 ProofGenerationInfo::new(format!("{}.{:?}", name, opname).as_str(), k, Poseidon);
+            // prover.mock_proof::<Bn256,_>(k as u32,&$circuit,&vec![]);
             let proof = prover.exec_create_proof(
                 &$circuit,
                 &vec![],
@@ -183,7 +184,6 @@ pub fn exec_create_host_proof(
                 OpenSchema::GWC,
             );
             prover.save_proof_data::<Fr>(&vec![], &proof, cache_folder);
-            //prover.mock_proof(k as u32);
             proof_gen_info.append_single_proof(prover);
             proof_gen_info.save(cache_folder);
         };


### PR DESCRIPTION
when pairing case,  the enable column are set true for all the  filtered operands.  but for the end filter case the sel_n may not be true as not operand row set.